### PR TITLE
Change projects and dependencies to use .Net 4.0

### DIFF
--- a/src/NUnit.Specifications.Specs/NUnit.Specifications.Specs.csproj
+++ b/src/NUnit.Specifications.Specs/NUnit.Specifications.Specs.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NUnit.Specifications.Specs</RootNamespace>
     <AssemblyName>NUnit.Specifications.Specs</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NUnit.Specifications.Specs/packages.config
+++ b/src/NUnit.Specifications.Specs/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Should" version="1.1.20" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="Should" version="1.1.20" targetFramework="net40" />
 </packages>

--- a/src/NUnit.Specifications/NUnit.Specifications.csproj
+++ b/src/NUnit.Specifications/NUnit.Specifications.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NUnit.Specifications</RootNamespace>
     <AssemblyName>NUnit.Specifications</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -35,7 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/src/NUnit.Specifications/packages.config
+++ b/src/NUnit.Specifications/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
We were trying to use this on a .Net 4.0 project. Unfortunately the NuGet package said it was 4.0, but the actual assemblies were complied against 4.5. So, we needed to make some minor project modifications to make things work.