### PR TITLE
Removed unnecessary test attribute + Updated references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ TestResult.xml
 node_modules
 yarn-error.log
 .yarnclean
+/src/.vs/NUnit.Specifications/v16

--- a/src/NUnit.Specifications.Net452.Specs/NUnit.Specifications.Net452.Specs.csproj
+++ b/src/NUnit.Specifications.Net452.Specs/NUnit.Specifications.Net452.Specs.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +14,8 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>
@@ -65,4 +69,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
+  </Target>
 </Project>

--- a/src/NUnit.Specifications.Net452.Specs/packages.config
+++ b/src/NUnit.Specifications.Net452.Specs/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Microsoft.NET.Test.Sdk" version="15.0.0" targetFramework="net462" />
   <package id="Microsoft.TestPlatform.TestHost" version="15.0.0" targetFramework="net462" />
-  <package id="NUnit" version="3.6.1" targetFramework="net462" />
+  <package id="NUnit" version="3.12.0" targetFramework="net452" />
   <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net452" />
-  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net462" />
+  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net452" />
   <package id="Should" version="1.1.20" targetFramework="net452" />
 </packages>

--- a/src/NUnit.Specifications.Specs/NUnit.Specifications.Specs.csproj
+++ b/src/NUnit.Specifications.Specs/NUnit.Specifications.Specs.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.7.10" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0-ci-00459-pr-313" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnit.Specifications/ContextSpecification.cs
+++ b/src/NUnit.Specifications/ContextSpecification.cs
@@ -160,7 +160,6 @@ namespace NUnit.Specifications
             }
         }
 
-        [Test]
         [SpecificationSource("GetObservations")]
         public void Observations(It observation)
         {

--- a/src/NUnit.Specifications/NUnit.Specifications.csproj
+++ b/src/NUnit.Specifications/NUnit.Specifications.csproj
@@ -15,12 +15,12 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="NUnit" Version="3.5.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NUnit.Specifications/SpecificationSourceAttribute.cs
+++ b/src/NUnit.Specifications/SpecificationSourceAttribute.cs
@@ -24,8 +24,9 @@ namespace NUnit.Specifications
         public IEnumerable<TestMethod> BuildFrom(IMethodInfo method, Test suite)
         {
             var classNameTokens = suite.FullName.Split('.', '+');
-            suite.FullName = classNameTokens[classNameTokens.Length - 1].Replace("_", " ");
-            suite.Name = suite.FullName;
+            string lastSegment = classNameTokens[classNameTokens.Length - 1];
+            suite.Name = lastSegment.Replace("_", " ");
+            suite.FullName = suite.FullName.Substring(0, suite.FullName.Length - lastSegment.Length - 1) + "." + suite.Name;
 
             foreach (var testCaseParameters in GetTestCasesFor(method))
                 yield return _builder.BuildTestMethod(method, suite, testCaseParameters);


### PR DESCRIPTION
The Observation method in ContextSpecification was marked erroneously with the [Test] attribute, this will make some weird behavior with Visual Studio TestRunner as you can see in the following picture.

I've removed the test attribute and Upgraded references to Nunit latest version.

![image](https://user-images.githubusercontent.com/358545/61465261-02397380-a978-11e9-9628-37f7e2b9b653.png)
